### PR TITLE
fix bug to catch when process id is not existing

### DIFF
--- a/src/flaskwebgui.py
+++ b/src/flaskwebgui.py
@@ -308,8 +308,11 @@ class FlaskUI:
             return
 
         while True:
-            gui_running = psutil.Process(self.BROWSER_PROCESS.pid).is_running()
-            gui_memory_usage = psutil.Process(self.BROWSER_PROCESS.pid).memory_percent()
+            try:
+                gui_running = psutil.Process(self.BROWSER_PROCESS.pid).is_running()
+                gui_memory_usage = psutil.Process(self.BROWSER_PROCESS.pid).memory_percent()
+            except psutil.NoSuchProcess:
+                gui_running = False
             
             if (
                 gui_running == False


### PR DESCRIPTION
Hi @ClimenteA 

Thank a lot for this awesome project! its really a nice package.

While using it I noticed that the server tread did not get stopped when closing the gui window.
looking at the docs for `psutil.Process` it seems appropiate to catch the `NoSuchProcess` exception.

I hope this can be of use.

Best regards,
Bjørn
