### PR TITLE
Correct subprocess.CalledProcessError on Linux

### DIFF
--- a/src/flaskwebgui.py
+++ b/src/flaskwebgui.py
@@ -11,6 +11,7 @@ from multiprocessing import Process
 from threading import Thread
 from dataclasses import dataclass
 from typing import Callable, Any, List, Union, Dict
+from contextlib import suppress
 
 
 OPERATING_SYSTEM = platform.system().lower()
@@ -45,7 +46,7 @@ def find_browser_on_linux():
             return path
 
     for path in paths:
-        try:
+        with suppress(subprocess.CalledProcessError):
             bp = (
                 subprocess.check_output(["which", path.split("/")[-1]])
                 .decode("utf-8")
@@ -53,8 +54,6 @@ def find_browser_on_linux():
             )
             if os.path.exists(bp):
                 return bp
-        except subprocess.CalledProcessError:
-            pass
 
     return None
 

--- a/src/flaskwebgui.py
+++ b/src/flaskwebgui.py
@@ -45,13 +45,16 @@ def find_browser_on_linux():
             return path
 
     for path in paths:
-        bp = (
-            subprocess.check_output(["which", path.split("/")[-1]])
-            .decode("utf-8")
-            .strip()
-        )
-        if os.path.exists(bp):
-            return bp
+        try:
+            bp = (
+                subprocess.check_output(["which", path.split("/")[-1]])
+                .decode("utf-8")
+                .strip()
+            )
+            if os.path.exists(bp):
+                return bp
+        except subprocess.CalledProcessError:
+            pass
 
     return None
 


### PR DESCRIPTION
```
  File "/usr/local/share/lib/python3.10/site-packages/flaskwebgui.py", line 49, in find_browser_on_linux
    subprocess.check_output(["which", path.split("/")[-1]])
  File "/usr/lib/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['which', 'google-chrome']' returned non-zero exit status 1.
```