### PR TITLE
add extra_flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Default FlaskUI class parameters:
 - `fullscreen: bool = True`: start app in fullscreen (maximized);
 - `on_startup: Callable = None`: function to before starting the browser and webserver;
 - `on_shutdown: Callable = None`: function to after the browser and webserver shutdown;
+- `extra_flags: List[str] = None`: list of additional flags for the browser command;
 - `browser_path: str = None`: set path to chrome executable or let the defaults do that;
 - `browser_command: List[str] = None`: command line with starts chrome in `app` mode;
 - `socketio: Any = None`: socketio instance in case of flask_socketio;

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("requirements.txt", "r") as r:
 
 setup(
     name="flaskwebgui",
-    version="1.1.0",
+    version="1.1.1",
     description="Create desktop applications with Flask/Django/FastAPI!",
     url="https://github.com/ClimenteA/flaskwebgui",
     author="Climente Alin",

--- a/src/flaskwebgui.py
+++ b/src/flaskwebgui.py
@@ -190,6 +190,7 @@ class FlaskUI:
     fullscreen: bool = True
     on_startup: Callable = None
     on_shutdown: Callable = None
+    extra_flags: List[str] = None
     browser_path: str = None
     browser_command: List[str] = None
     socketio: Any = None
@@ -241,6 +242,9 @@ class FlaskUI:
             flags.extend([f"--window-size={self.width},{self.height}"])
         elif self.fullscreen:
             flags.extend(["--start-maximized"])
+
+        for flag in self.extra_flags:
+            flags.extend([flag])
 
         flags.extend([f"--app={self.url}"])
 

--- a/src/flaskwebgui.py
+++ b/src/flaskwebgui.py
@@ -243,8 +243,9 @@ class FlaskUI:
         elif self.fullscreen:
             flags.extend(["--start-maximized"])
 
-        for flag in self.extra_flags:
-            flags.extend([flag])
+        if self.extra_flags:
+            for flag in self.extra_flags:
+                flags.extend([flag])
 
         flags.extend([f"--app={self.url}"])
 


### PR DESCRIPTION
Adds extra_flags option. This allows you to insert additional flags into the browser command.
For example, I use with --guest so that when you type text in the password field, it doesn't ask whether to save it.