### PR TITLE
feat: find web browser via flatpak portals 

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,13 +334,20 @@ Checkout `examples` for more information.
 
 You can distribute it as a standalone desktop app with **pyinstaller** or [**pyvan**](https://github.com/ClimenteA/pyvan). If pyinstaller failes try pyinstaller version 5.6.2.
 
-
 ```shell
 pyinstaller -w -F  main.py
 ```
 
 After the command finishes move your files (templates, js,css etc) to the `dist` folder created by pyinstaller.
 
+If you want your desktop application to be available to many Linux users you can publish your application as a [flatpak](https://flathub.org/), to do this, you must:
+
+1. Include a icon file.
+2. Include a .desktop launcher.
+3. Write your xml.metainfo file.
+4. Create a flatpak manifest. 
+
+Detailed info is avalible in the [flatpak docs](https://docs.flatpak.org/en/latest/conventions.html).
 
 ## Observations
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("requirements.txt", "r") as r:
 
 setup(
     name="flaskwebgui",
-    version="1.1.1",
+    version="1.1.2",
     description="Create desktop applications with Flask/Django/FastAPI!",
     url="https://github.com/ClimenteA/flaskwebgui",
     author="Climente Alin",

--- a/src/flaskwebgui.py
+++ b/src/flaskwebgui.py
@@ -52,19 +52,13 @@ def find_browser_on_linux():
         r"/usr/bin/microsoft-edge",
         r"/usr/bin/brave-browser",
         r"/usr/bin/chromium",
-        # System installed web browser made avaible via sandbox permissions for apps
-        # running as flatpak. This requiere make the host-os accesible to the flatpak
-        # See:
-        # - https://docs.flatpak.org/en/latest/sandbox-permissions.html
-        #
-        # host-os: Everything in host and /usr, /bin, /sbin, /lib{32, 64} /usr is mounted at /run/host/usr
-        #
+        # Web browsers installed via flatpak portals
         r"/run/host/usr/bin/google-chrome",
         r"/run/host/usr/bin/microsoft-edge-stable",
         r"/run/host/usr/bin/microsoft-edge",
         r"/run/host/usr/bin/brave-browser",
         r"/run/host/usr/bin/chromium",
-        # Web browsers installed vía snap
+        # Web browsers installed via snap
         r"/snap/bin/chromium",
         r"/snap/bin/brave-browser",
         r"/snap/bin/google-chrome",

--- a/src/flaskwebgui.py
+++ b/src/flaskwebgui.py
@@ -52,6 +52,19 @@ def find_browser_on_linux():
         r"/usr/bin/microsoft-edge",
         r"/usr/bin/brave-browser",
         r"/usr/bin/chromium",
+        # System installed web browser made avaible via sandbox permissions for apps
+        # running as flatpak. This requiere make the host-os accesible to the flatpak
+        # See:
+        # - https://docs.flatpak.org/en/latest/sandbox-permissions.html
+        #
+        # host-os: Everything in host and /usr, /bin, /sbin, /lib{32, 64} /usr is mounted at /run/host/usr
+        #
+        r"/run/host/usr/bin/google-chrome",
+        r"/run/host/usr/bin/microsoft-edge-stable",
+        r"/run/host/usr/bin/microsoft-edge",
+        r"/run/host/usr/bin/brave-browser",
+        r"/run/host/usr/bin/chromium",
+        # Web browsers installed vía snap
         r"/snap/bin/chromium",
         r"/snap/bin/brave-browser",
         r"/snap/bin/google-chrome",


### PR DESCRIPTION
Hello

I am playing with the packaging as flatpak of app using flaskwebgui to serve a flask app as desktop app.

By default apps running as flatpak have very limited access to the host system.

To have access to the host system you must provide ```--filesystem=host-os:ro``` to access the ```/usr/bin``` dir that become available under ```/run/host/usr```

The proposed changes include these dir to find a web brower after looking at a system installed one. 

I certify that the proposed changes are my authorship and I agree that they will be included in the source code of the application under the terms of the project license.