### PR TITLE
add fix for Flask-SocketIO >=5.3.0

### DIFF
--- a/src/flaskwebgui.py
+++ b/src/flaskwebgui.py
@@ -166,7 +166,9 @@ class DefaultServerFlaskSocketIO:
     @staticmethod
     def server(**server_kwargs):
         server_kwargs["flask_socketio"].run(
-            server_kwargs["app"], port=server_kwargs["port"]
+            server_kwargs["app"],
+            port=server_kwargs["port"],
+            allow_unsafe_werkzeug=True  # required for Flask-SocketIO >=5.3.0
         )
 
 


### PR DESCRIPTION
Flask-Socketio introduced in release 5.3.0 _Do not allow Werkzeug to be used in production by default_:
https://github.com/miguelgrinberg/Flask-SocketIO/blob/main/CHANGES.md

When using flaskwebgui in windowed mode, this causes
```bash
Command: C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe --user-data-dir=C:\Users\...\AppData\Local\Temp\flaskwebgui5481c963b6b54b8c88b5fec57c7c5a2c --new-window --no-default-browser-check --allow-insecure-localhost --no-first-run --disable-sync --window-size=1400,900 --app=http://127.0.0.1:52565
    self.run()
  File "C:\Users\...\AppData\Local\Programs\Python\Python312\Lib\threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\...\workspace\...\.venv\Lib\site-packages\flaskwebgui.py", line 168, in server
    server_kwargs["flask_socketio"].run(
  File "C:\Users\...\workspace\...\.venv\Lib\site-packages\flask_socketio\__init__.py", line 650, in run
    raise RuntimeError('The Werkzeug web server is not '
RuntimeError: The Werkzeug web server is not designed to run in production. Pass allow_unsafe_werkzeug=True to the run() method to disable this error.
```

`allow_unsafe_werkzeug=True` needs to be set to fix that.