### PR TITLE
Fix a syntax error in logger in ` src/flaskwebgui.py`

### DIFF
--- a/src/flaskwebgui.py
+++ b/src/flaskwebgui.py
@@ -274,7 +274,7 @@ class FlaskUI:
     
     
     def start_browser(self, server_process: Union[Thread, Process]):
-        logger.info(f"Command: {" ".join(self.browser_command)}")
+        logger.info(f"Command: {' '.join(self.browser_command)}")
         global FLASKWEBGUI_BROWSER_PROCESS
 
         FLASKWEBGUI_BROWSER_PROCESS = subprocess.Popen(self.browser_command)


### PR DESCRIPTION
Although this change has no effect in Python 3.12+, people running Python 3.11 or below (I have 3.11) will encounter a syntax error when trying to run FlaskWebGUI.
The problem is the usage of nested double quotes. The fix is simply to use single quotes inside the double quotes in the same string.